### PR TITLE
feat: autoupdate command

### DIFF
--- a/internal/command/autoupdate/autoupdate.go
+++ b/internal/command/autoupdate/autoupdate.go
@@ -1,0 +1,43 @@
+package autoupdate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/cache"
+
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	const (
+		short = "Auto-update setting for flyctl CLI"
+
+		long = `Auto-update setting for flyctl command. Default is OFF.`
+	)
+
+	cmd := command.New("autoupdate", short, long, runAutoUpdate)
+
+	cmd.AddCommand(
+		newSet("on", true),
+		newSet("off", false),
+	)
+
+	return cmd
+}
+
+func runAutoUpdate(ctx context.Context) (err error) {
+	cache := cache.FromContext(ctx)
+
+	var autoUpdate string;
+	if (cache.AutoUpdate()) {
+		autoUpdate = "ON"
+	} else {
+		autoUpdate = "OFF"
+	}
+
+	fmt.Println("auto-update:", autoUpdate)
+	return
+}
+

--- a/internal/command/autoupdate/set.go
+++ b/internal/command/autoupdate/set.go
@@ -1,0 +1,29 @@
+package autoupdate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/cache"
+	"github.com/superfly/flyctl/internal/command"
+)
+
+func newSet(usage string, setting bool) (cmd *cobra.Command) {
+	var (
+		long  = fmt.Sprintf("Set auto-update %s", strings.ToUpper(usage))
+		short = long
+	)
+
+	return command.New(usage, short, long, runSet(usage, setting))
+}
+
+func runSet(usage string, setting bool) func(ctx context.Context) (err error) {
+		return func(ctx context.Context) (err error) {
+				c := cache.FromContext(ctx)
+				c.SetAutoUpdate(setting)
+				fmt.Println("auto-update:", strings.ToUpper(usage))
+				return
+		}
+}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -375,14 +375,21 @@ func promptToUpdate(ctx context.Context) (context.Context, error) {
 
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
-
-	msg := fmt.Sprintf("Update available %s -> %s.\nRun \"%s\" to upgrade.",
-		current,
-		r.Version,
-		colorize.Bold(buildinfo.Name()+" version update"),
-	)
-
+	
+	msg := fmt.Sprintf("Update available %s -> %s.", current, r.Version)
 	fmt.Fprintln(io.ErrOut, colorize.Yellow(msg))
+
+	if (c.AutoUpdate()) {
+		msg = fmt.Sprintf("Automatically updating to %s.", r.Version,)
+		fmt.Fprintln(io.ErrOut, colorize.Green(msg))
+		io := iostreams.FromContext(ctx)
+		update.UpgradeInPlace(ctx, io, r.Prerelease)
+	} else {
+		msg := fmt.Sprintf("Run \"%s\" to upgrade.",
+			colorize.Bold(buildinfo.Name()+" version update"),
+		)
+		fmt.Fprintln(io.ErrOut, colorize.Yellow(msg))
+	}
 
 	return ctx, nil
 }

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/agent"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/command/auth"
+	"github.com/superfly/flyctl/internal/command/autoupdate"
 	"github.com/superfly/flyctl/internal/command/checks"
 	"github.com/superfly/flyctl/internal/command/create"
 	"github.com/superfly/flyctl/internal/command/curl"
@@ -121,6 +122,7 @@ func New() *cobra.Command {
 	newCommands := []*cobra.Command{
 		version.New(),
 		apps.New(),
+		autoupdate.New(),
 		create.New(),  // TODO: deprecate
 		destroy.New(), // TODO: deprecate
 		move.New(),    // TODO: deprecate


### PR DESCRIPTION
# Motivation

It's a pain to always have to manually update.

# What

Adds an autoupdate command.

Usage:

  `flyctl autoupdate`: show current setting
  `flyctl autoupdate on`: turn on
  `flyctl autoupdate off`: turn off

Instead of a command instructing users to update with `fly version update`, the CLI will simply go ahead and update.

# How

Uses the "cache" (`~/.fly/state.yml`) to persist an auto update flag.

# Result

My local development version of flyctl is in my home folder.


### Autoupdate show

```
 ~/flyctl/bin/flyctl autoupdate
auto-update: OFF
```

### Autoupdate OFF

```
 ~ FLY_UPDATE_CHECK=true ~/flyctl/bin/flyctl autoupdate off
Update available 0.0.0-1666391672+dev -> v0.0.416.
Run "flyctl version update" to upgrade.
auto-update: OFF
```

### Autoupdate ON
```
~ FLY_UPDATE_CHECK=true ~/flyctl/bin/flyctl autoupdate on
Update available 0.0.0-1666391672+dev -> v0.0.416.
Run "flyctl version update" to upgrade.
auto-update: ON
```


### Auto updating (while calling 'flyctl version'; autoupdate: ON)

```
 ~ FLY_UPDATE_CHECK=true ~/flyctl/bin/flyctl version
Update available 0.0.0-1666391672+dev -> v0.0.416.
Automatically updating to v0.0.416.
/bin/zsh -c
Running automatic update [curl -L "https://fly.io/install.sh" | sh]
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1475    0  1475    0     0   3655      0 --:--:-- --:--:-- --:--:--  3734
######################################################################## 100.0%
set channel to shell
flyctl was installed successfully to /Users/nathan/.fly/bin/flyctl
Run 'flyctl --help' to get started
```
<img width="624" alt="Screenshot 2022-10-22 at 7 55 36" src="https://user-images.githubusercontent.com/3220620/197302387-0f40bb7d-1d94-452a-b0a2-12c5035de2c6.png">



# Question for reviewer

Would the cache be reset each time I upgrade? In other words, would the cached `autocomplete` be reset after a CLI update? As far as I can tell that isn't the case.

# Note

I'm not a golang developer, so I don't know the conventions. I'd be perfectly happy if this PR was closed and reimplemented by a developer at Fly. 


